### PR TITLE
docs: Add FAQ entry for Track B/C dual kernel submission requirement

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -40,6 +40,10 @@ Decode and prefill are separate definitions. Our final score is the average spee
 
 Maximum **5 members** per team.
 
+**Q: For Tracks B/C, do teams need to submit both kernels?**
+
+Teams are expected to submit both operators/kernels for Tracks B/C, and the ranking is based on the average performance across the two. If only one of the two operators is submitted or correct, your ranking score will be half of the score of the correct operator.
+
 ---
 
 ## Official Evaluation Environment


### PR DESCRIPTION
Update FAQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on submission requirements for Tracks B/C competitions. Teams must submit both operators and kernels for evaluation. Ranking calculations use the average of both submitted components. Submitting only one correct component results in a score equal to half of that component's individual score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->